### PR TITLE
fix: replace Nanosecond with Microsecond in String(ITime) and String(IDateTime) format

### DIFF
--- a/src/Pure.Primitives/String/String.cs
+++ b/src/Pure.Primitives/String/String.cs
@@ -33,7 +33,7 @@ public sealed record String : IString
     public String(IDateTime value)
         : this(
             new Lazy<string>(() =>
-                $"{value.Month.NumberValue}/{value.Day.NumberValue}/{value.Year.NumberValue} {value.Hour.NumberValue}:{value.Minute.NumberValue}:{value.Second.NumberValue}.{value.Millisecond.NumberValue}.{value.Nanosecond.NumberValue}"
+                $"{value.Month.NumberValue}/{value.Day.NumberValue}/{value.Year.NumberValue} {value.Hour.NumberValue}:{value.Minute.NumberValue}:{value.Second.NumberValue}.{value.Millisecond.NumberValue}.{value.Microsecond.NumberValue}"
             )
         )
     { }
@@ -41,7 +41,7 @@ public sealed record String : IString
     public String(ITime value)
         : this(
             new Lazy<string>(() =>
-                $"{value.Hour.NumberValue}:{value.Minute.NumberValue}:{value.Second.NumberValue}.{value.Millisecond.NumberValue}.{value.Nanosecond.NumberValue}"
+                $"{value.Hour.NumberValue}:{value.Minute.NumberValue}:{value.Second.NumberValue}.{value.Millisecond.NumberValue}.{value.Microsecond.NumberValue}"
             )
         )
     { }

--- a/src/Tests/Pure.Primitives.Tests/String/StringTests.cs
+++ b/src/Tests/Pure.Primitives.Tests/String/StringTests.cs
@@ -57,7 +57,7 @@ public sealed record StringTests
         IDateTime value = new RandomDateTime();
         IString parsed = new String(value);
         Assert.Equal(
-            $"{value.Month.NumberValue}/{value.Day.NumberValue}/{value.Year.NumberValue} {value.Hour.NumberValue}:{value.Minute.NumberValue}:{value.Second.NumberValue}.{value.Millisecond.NumberValue}.{value.Nanosecond.NumberValue}",
+            $"{value.Month.NumberValue}/{value.Day.NumberValue}/{value.Year.NumberValue} {value.Hour.NumberValue}:{value.Minute.NumberValue}:{value.Second.NumberValue}.{value.Millisecond.NumberValue}.{value.Microsecond.NumberValue}",
             parsed.TextValue
         );
     }
@@ -68,7 +68,7 @@ public sealed record StringTests
         ITime value = new RandomTime();
         IString parsed = new String(value);
         Assert.Equal(
-            $"{value.Hour.NumberValue}:{value.Minute.NumberValue}:{value.Second.NumberValue}.{value.Millisecond.NumberValue}.{value.Nanosecond.NumberValue}",
+            $"{value.Hour.NumberValue}:{value.Minute.NumberValue}:{value.Second.NumberValue}.{value.Millisecond.NumberValue}.{value.Microsecond.NumberValue}",
             parsed.TextValue
         );
     }


### PR DESCRIPTION
Fixes #319

`String(ITime)` and `String(IDateTime)` were referencing `Nanosecond` instead of `Microsecond` in the formatted output, silently dropping the microsecond component. Updated both constructors in `String.cs` and the corresponding assertions in `StringTests.cs`.