### PR TITLE
Update package validation baseline to 3.6.5

### DIFF
--- a/src/Pure.Primitives/Pure.Primitives.csproj
+++ b/src/Pure.Primitives/Pure.Primitives.csproj
@@ -6,7 +6,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <LangVersion>latest</LangVersion>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>3.6.4</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.6.5</PackageValidationBaselineVersion>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Pure.Primitives.Tests" />


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `3.6.4` to `3.6.5` following the successful publish.